### PR TITLE
test: add pytest suite for sorting algorithms and fix bidirectional sort (#33)

### DIFF
--- a/sorting/selectionsort.py
+++ b/sorting/selectionsort.py
@@ -197,24 +197,17 @@ def bidirectional_selection_sort(arr: List[T]) -> List[T]:
             if result[i] > result[max_idx]:
                 max_idx = i
 
-        # Special case: if min_idx == right, we need to swap it first
-        # Otherwise, when we swap max_idx to right, we might move the min
-        if min_idx == right:
-            result[left], result[right] = result[right], result[left]
-            if max_idx == left:
-                max_idx = right
-        else:
-            # Swap minimum to the left boundary
-            if min_idx != left:
-                result[left], result[min_idx] = result[min_idx], result[left]
+        # Swap minimum to the left boundary
+        if min_idx != left:
+            result[left], result[min_idx] = result[min_idx], result[left]
 
-            # If maximum was at left position, it's now at min_idx
-            if max_idx == left:
-                max_idx = min_idx
+        # If maximum was at left position, it's now at min_idx
+        if max_idx == left:
+            max_idx = min_idx
 
-            # Swap maximum to the right boundary
-            if max_idx != right:
-                result[right], result[max_idx] = result[max_idx], result[right]
+        # Swap maximum to the right boundary
+        if max_idx != right:
+            result[right], result[max_idx] = result[max_idx], result[right]
 
         # Move boundaries inward
         left += 1

--- a/sorting/test_sorting.py
+++ b/sorting/test_sorting.py
@@ -1,0 +1,88 @@
+import pytest
+
+from bubblesort import (
+    bubble_sort_iterative,
+    bubble_sort_optimized,
+    bubble_sort_in_place,
+    bubble_sort_recursive,
+    bubble_sort_functional,
+    cocktail_sort
+)
+
+from heapsort import (
+    heap_sort,
+    heap_sort_in_place
+)
+
+from insertionsort import (
+    insertion_sort,
+    insertion_sort_in_place,
+    insertion_sort_recursive,
+    binary_insertion_sort,
+    shell_sort,
+    hybrid_insertion_sort
+)
+
+from mergesort import (
+    merge_sort_recursive,
+    merge_sort_in_place,
+    merge_sort_iterative
+)
+
+from selectionsort import (
+    selection_sort,
+    selection_sort_in_place,
+    bidirectional_selection_sort,
+    selection_sort_recursive,
+    stable_selection_sort
+)
+
+ALGORITHMS = [
+    bubble_sort_iterative,
+    bubble_sort_optimized,
+    bubble_sort_in_place,
+    bubble_sort_recursive,
+    bubble_sort_functional,
+    cocktail_sort,
+    heap_sort,
+    heap_sort_in_place,
+    insertion_sort,
+    insertion_sort_in_place,
+    insertion_sort_recursive,
+    binary_insertion_sort,
+    shell_sort,
+    hybrid_insertion_sort,
+    merge_sort_recursive,
+    merge_sort_in_place,
+    merge_sort_iterative,
+    selection_sort,
+    selection_sort_in_place,
+    bidirectional_selection_sort,
+    selection_sort_recursive,
+    stable_selection_sort
+]
+
+TEST_CASES = [
+    [],
+    [42],
+    [1, 2, 3, 4, 5, 6],
+    [9, 8, 7, 6, 5, 4],
+    [3, 1, 4, 1, 5, 9, 2, 6, 5],
+    [-5, 0, 5, -10, 20]
+]
+
+@pytest.mark.parametrize("algorithm", ALGORITHMS)
+@pytest.mark.parametrize("test_case", TEST_CASES)
+
+def test_sorting_algorithm(algorithm, test_case):
+    # Copy the input test case
+    arr = test_case.copy()
+    # Run the algorithm
+    result = algorithm(arr)
+
+    # Some algorithms sort in-place and return None
+    # otherwise they return the new sorted list.
+    sorted_result = result if result is not None else arr
+    
+    # Validate against Python's built-in sorted function
+    assert sorted_result == sorted(test_case)


### PR DESCRIPTION
Changes:

I've implemented a pytest suite in sorting/test_sorting.py that tests all algorithms against edge cases (empty, duplicates, reverse sorted, negative numbers)

During testing, the suite caught a pointer displacement bug in bidirectional_selection_sort (it failed on duplicates and negative numbers)

When the array had negatives or duplicates, sometimes the smallest number would end up at the very end of the line.
The original code successfully moved that small number to the front, but then it skipped a step and forgot to move the biggest number to the back.

So I've added a fix to bidirectional_selection_sort so it correctly updates max_idx if the maximum element is moved during the first swap. All 132 tests now pass.

Also, this is actually my first open-source PR, so please let me know if I need to adjust anything or format something differently!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `pytest` suite for all sorting algorithms and fix `bidirectional_selection_sort` for duplicates and negative numbers. Now 132 tests pass.

- **New Features**
  - Added `sorting/test_sorting.py` using `pytest` to validate 22 algorithms across 6 cases (empty, single, sorted, reverse, duplicates, negatives).
  - Supports algorithms that sort in-place or return a new list by normalizing the result before asserting.

- **Bug Fixes**
  - Updated `bidirectional_selection_sort` to swap the min first, adjust `max_idx` if it was at `left`, then swap the max to `right`. Fixes failures with duplicates and negatives.

<sup>Written for commit 709b4280574a9d62a091d588fda228526587cdf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

